### PR TITLE
privacy statement popover

### DIFF
--- a/death-causes-app/src/components/DataPrivacyBox.tsx
+++ b/death-causes-app/src/components/DataPrivacyBox.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import OverlayTrigger from "react-bootstrap/OverlayTrigger";
+import Button from "react-bootstrap/Button";
+import Popover from "react-bootstrap/Popover";
+
+export default class DataPrivacyBox extends React.PureComponent {
+  helpBox() {
+    return (
+      <Popover id="popover-basic">
+        <Popover.Title as="h3">Privacy</Popover.Title>
+        <Popover.Content>{
+            this.getPrivacyText()
+        }</Popover.Content>
+      </Popover>
+    );
+  }
+
+  getPrivacyText(){
+      return "The answers to the questions are not saved anywhere. Be careful not to refresh the page because that will erase any progress."
+  }
+
+  render() {
+    return (
+      <OverlayTrigger
+        trigger="click"
+        rootClose={true}
+        placement={"bottom"}
+        overlay={this.helpBox()}
+      >
+        <Button variant="link">
+          (Privacy)
+        </Button>
+      </OverlayTrigger>
+    );
+  }
+}

--- a/death-causes-app/src/components/QuestionMenu.tsx
+++ b/death-causes-app/src/components/QuestionMenu.tsx
@@ -21,6 +21,7 @@ import RelationLinks from "../models/RelationLinks";
 import { OrderVisualization } from "./Helpers";
 import QuestionListFrame from "./QuestionListFrame";
 import factorDatabase from "../resources/FactorDatabase.json";
+import DataPrivacyBox from "./DataPrivacyBox";
 
 interface QuestionMenuProps extends OrderVisualization {
   handleSuccessfulSubmit: (f: FactorAnswers) => void;
@@ -614,8 +615,8 @@ class QuestionMenu extends React.Component<
     return (
       <div>
         <p>
-          Input risk factors to calculate probability of dying of most diseases
-          and expected lifespan
+          Answer questions to get personalized risks of dying from different causes  
+          <DataPrivacyBox></DataPrivacyBox>
         </p>
           <Collapse
             in={this.state.view === QuestionView.QUESTION_MANAGER}


### PR DESCRIPTION
Jeg har lagt privacy statement'et ind som en <button type=link> med en popover og så vurderede jeg også at vi ikke behøver skrive "input" men kan nu skrive "answer" fordi alle risikofaktorerne nu præsenteres som spørgsmål.