### PR TITLE
relationlink animations, removed cause category special status

### DIFF
--- a/death-causes-app/src/components/RelationLinkViz.tsx
+++ b/death-causes-app/src/components/RelationLinkViz.tsx
@@ -12,7 +12,7 @@ import RelationLinks, {
 import { ALTERNATING_COLORS, getDivWidth } from "./Helpers";
 import "./RelationLinkViz.css";
 
-const SLIGHTLY_DARKER_GRAY="#aaaaaa"
+const SLIGHTLY_DARKER_GRAY="#707070"
 interface PlottingNodeDicValue {
   bbox: SVGRect;
   x: number;
@@ -105,7 +105,7 @@ export default class RelationLinkViz {
         return undefined;
       })
       .style("fill", SLIGHTLY_DARKER_GRAY)
-      .style("font-size","12px")
+      .style("font-size","14px")
       .attr("text-anchor", "start")
       .attr("alignment-baseline", "hanging")
       .style("opacity", function(d:any){

--- a/death-causes-app/src/components/RelationLinkViz.tsx
+++ b/death-causes-app/src/components/RelationLinkViz.tsx
@@ -87,7 +87,7 @@ export default class RelationLinkViz {
       .attr("y", y(yfromDomain))
       .attr("height", y(ytoDomain) - y(yfromDomain))
       .style("fill", (d: any) => d.color)
-      .style("opacity", 0.5);
+      .style("opacity", 0.8);
 
     const categoryText = this.svg.selectAll(".cattext")
       .data(xDivisions, function (d: any) {
@@ -354,7 +354,7 @@ export default class RelationLinkViz {
       .attr("x", (d: any) => x(d.x0))
       .attr("width", (d: any) => x(d.x0 + d.width) - x(d.x0))
       .style("fill", (d: any) => d.color)
-      .style("opacity", 0.5);
+      .style("opacity", 0.8);
 
 
     const categoryText = this.svg.selectAll(".cattext")

--- a/death-causes-app/src/components/RelationLinkViz.tsx
+++ b/death-causes-app/src/components/RelationLinkViz.tsx
@@ -6,11 +6,13 @@ import RelationLinks, {
   NODE_ORDER,
   PlottingInfo,
   TransformedLabel,
-  NodeExtremas
+  NodeExtremas,
+  XDivision,
 } from "../models/RelationLinks";
 import { ALTERNATING_COLORS, getDivWidth } from "./Helpers";
 import "./RelationLinkViz.css";
 
+const SLIGHTLY_DARKER_GRAY="#aaaaaa"
 interface PlottingNodeDicValue {
   bbox: SVGRect;
   x: number;
@@ -19,7 +21,6 @@ interface PlottingNodeDicValue {
   cat: string;
   nodeName: string;
 }
-
 
 interface PlottingNodeDic {
   [key: string]: PlottingNodeDicValue;
@@ -34,112 +35,101 @@ interface ArrowExtender {
 
 interface ArrowPlottingObject extends Arrow, ArrowExtender {}
 
-
-
 export default class RelationLinkViz {
+  rdat: RelationLinks;
+  changeElementInFocus: (d: string) => void;
+  width: number = 0;
+  svg!: d3.Selection<SVGSVGElement, unknown, null, undefined>;
+
   constructor(
     canvas: HTMLElement | null,
     rdat: RelationLinks,
     elementInFocus: string,
     changeElementInFocus: (d: string) => void
   ) {
-    const width = getDivWidth(canvas);
+    this.width = getDivWidth(canvas);
     console.log("wdth");
-    console.log(width);
-    const pdat: PlottingInfo = rdat.makePlottingInstructions(elementInFocus);
-    const transformedLabels = pdat.transformedLabels;
-    const arrows = pdat.arrows;
-    let nodeExtremas= pdat.nodeExtremas
-    if(nodeExtremas.min===nodeExtremas.max){
-      nodeExtremas.min=NODE_ORDER[0]
-      nodeExtremas.max=NODE_ORDER[NODE_ORDER.length-1]
-    }
+    console.log(this.width);
+    this.rdat = rdat;
+    this.changeElementInFocus = changeElementInFocus;
 
-    console.log("transformedlabels");
-    console.log(transformedLabels);
-    console.log(pdat.xDivisions);
-
-    const xDivisions = pdat.xDivisions;
-    const svg = d3
+    this.svg = d3
       .select(canvas)
       .append("svg")
-      .attr("width", Math.max(width - 10, 800))
+      .attr("width", Math.max(this.width - 10, 800))
       .attr("height", 1000);
+    const vis = this;
 
-    const maxX = Math.max(getMax(transformedLabels, "x"),0.01); //making sure that x is positive to handle the case where there are only one variable.
-    const maxY = getMax(transformedLabels, "y");
+    const {
+      transformedLabels,
+      arrows,
+      nodeExtremas,
+      xDivisions,
+    } = this.computeDataTransformations(elementInFocus);
 
-    const x = d3
-      .scaleLinear()
-      .domain([-maxX * 0.05, maxX * 1.05])
-      .range([0.1, Math.max(width - 10, 800) * 0.9]);
+    const { x, y, yfromDomain, ytoDomain } = this.computeAxes(
+      transformedLabels
+    );
 
-    const yfromDomain = -0.5;
-    const ytoDomain = Math.max(10, maxY);
-    const y = d3.scaleLinear().domain([yfromDomain, ytoDomain]).range([0, 800]);
-
-    const backgroundBoxes = svg
-      .selectAll("rect")
-      .data(xDivisions)
+    const backgroundBoxes = this.svg
+      .selectAll(".darkrect")
+      .data(xDivisions, function (d: any) {
+        return d.cat;
+      })
       .enter()
       .append("rect")
+      .call((selection) => {
+        insertColor(selection, xDivisions);
+      })
+      .attr("class", "darkrect")
       .attr("x", (d: any) => x(d.x0))
       .attr("width", (d: any) => x(d.x0 + d.width) - x(d.x0))
       .attr("y", y(yfromDomain))
       .attr("height", y(ytoDomain) - y(yfromDomain))
-      .attr("fill", function (d: any, i: number) {
-        return ALTERNATING_COLORS[i % 2];
+      .style("fill", (d: any) => d.color)
+      .style("opacity", 0.5);
+
+    const categoryText = this.svg.selectAll(".cattext")
+      .data(xDivisions, function (d: any) {
+        return d.cat;
       })
-      .attr("opacity", 0.5);
+      .enter()
+      .append("text")
+      .attr("class","cattext")
+      .attr("x", (d:any) => x(d.x0))
+      .attr("y", y(yfromDomain))
+      .text( function(d:any){
+        if(d.width>0){
+          return d.cat;
+        }
+        return undefined;
+      })
+      .style("fill", SLIGHTLY_DARKER_GRAY)
+      .style("font-size","12px")
+      .attr("text-anchor", "start")
+      .attr("alignment-baseline", "hanging")
+      .style("opacity", function(d:any){
+        if(d.width>0){
+          return 1;
+        }
+        return 0;
+      })
 
 
 
-    const stext = svg
-      .selectAll("text")
+    const stext = this.svg
+      .selectAll(".linktext")
       .data(transformedLabels, function (d: any) {
         return d.nodeName;
       })
       .enter()
       .append("text")
+      .attr("class", "linktext")
       .attr("y", (d: any) => y(d.y) as number)
       .attr("x", (d: any) => x(d.x) as number)
-      .text((d: any) => d.nodeName)
-      .attr("text-anchor", (d: any) => {
-        if (d.cat === nodeExtremas.min) {
-          return "start";
-        }
-        if (d.cat === nodeExtremas.max) {
-          return "end";
-        } else {
-          return "middle";
-        }
-      })
-      .style("fill", function (d: any) {
-        return d.cat === NodeType.CAUSE_CATEGORY
-          ? null
-          : d.nodeName === elementInFocus
-          ? "#551A8B"
-          : "#0000EE";
-      })
-      .style("text-decoration", function (d: any) {
-        return d.cat === NodeType.CAUSE_CATEGORY ? null : "underline";
-      })
-      .style("font-weight", function (d: any) {
-        return d.nodeName === elementInFocus ? 700 : null;
-      })
-      .style("cursor", function (d: any) {
-        return d.cat === NodeType.CAUSE_CATEGORY ? null : "pointer";
-      })
-      .attr("alignment-baseline", "central")
-      .on("click", function (e: Event, d: TransformedLabel) {
-        changeElementInFocus(d.nodeName);
-      })
-      .call(insertBB);
-    stext.each(function (d: any, i: number) {
-      console.log(this.getBBox());
-    });
+      .text((d: any) => d.nodeName);
 
-    console.log(transformedLabels);
+    this.addTextProperties(stext, elementInFocus, nodeExtremas);
 
     let nodeDic: PlottingNodeDic = {};
 
@@ -150,14 +140,18 @@ export default class RelationLinkViz {
     let adjustedArrows = arrows.map((a: Arrow) => {
       return {
         ...a,
-        ...computeArrowEndPoints(nodeDic[a.from], nodeDic[a.to], x, y, nodeExtremas),
+        ...computeArrowEndPoints(
+          nodeDic[a.from],
+          nodeDic[a.to],
+          x,
+          y,
+          nodeExtremas
+        ),
       };
     });
-    console.log(adjustedArrows);
-    console.log(nodeDic);
 
     //taken from https://stackoverflow.com/questions/36579339/how-to-draw-line-with-arrow-using-d3-js
-    svg
+    this.svg
       .append("svg:defs")
       .append("svg:marker")
       .attr("id", "triangle")
@@ -172,12 +166,13 @@ export default class RelationLinkViz {
 
     d3.select(".arrowexplanation").remove(); //removes any old visible tooltips that was perhaps not removed by a mouseout event (for example because the mouse teleported instantanously by entering/exiting a full-screen).
 
-    var tooltipdiv = d3.select('body')
+    var tooltipdiv = d3
+      .select("body")
       .append("div")
       .attr("class", "arrowexplanation")
       .style("opacity", 0);
 
-    const underlines = svg
+    const underlines = this.svg
       .selectAll(".underlines")
       .data(adjustedArrows, function (d: any) {
         return d.from + " - " + d.to;
@@ -195,7 +190,7 @@ export default class RelationLinkViz {
         return d.type === "arrow" ? "url(#triangle)" : null;
       });
 
-    const overlines = svg
+    const overlines = this.svg
       .selectAll(".overlines")
       .data(adjustedArrows, function (d: any) {
         return d.from + " - " + d.to;
@@ -211,8 +206,24 @@ export default class RelationLinkViz {
       .attr("stroke", "black")
       .attr("opacity", 0)
       .attr("cursor", "pointer")
+      .call((select) => {
+        this.addFunctionalityToOverLines(select);
+      });
+
+    vis.svg.on("click", () => {
+      tooltipdiv.style("opacity", 0);
+    });
+    vis.svg.on("mouseleave", () => {
+      tooltipdiv.style("opacity", 0);
+    });
+  }
+
+  addFunctionalityToOverLines(overlines: d3.Selection<any, any, any, any>) {
+    const vis = this;
+    const tooltipdiv = d3.select(".arrowexplanation");
+    overlines
       .on("mouseover", function (e: Event, d: ArrowPlottingObject) {
-        svg
+        vis.svg
           .selectAll(".underlines")
           .filter(function (ud: any) {
             {
@@ -222,7 +233,7 @@ export default class RelationLinkViz {
           .attr("stroke-width", 3);
       })
       .on("mouseout", function (e: Event, d: ArrowPlottingObject) {
-        svg
+        vis.svg
           .selectAll(".underlines")
           .filter(function (ud: any) {
             {
@@ -233,31 +244,280 @@ export default class RelationLinkViz {
       })
       .on("click", function (e: MouseEvent, d: ArrowPlottingObject) {
         var x = e.pageX; //x position within the element.
-        var y = e.pageY;  //y position within the element.
+        var y = e.pageY; //y position within the element.
         tooltipdiv
           .style("opacity", 1)
-          .html(`${rdat.arrowInterpretation(d.from, d.to)}`)
+          .html(`${vis.rdat.arrowInterpretation(d.from, d.to)}`)
           .style("left", x + "px")
           .style("top", y + "px");
         e.stopPropagation();
       });
-    svg.on("click", () => {
-      tooltipdiv.style("opacity", 0);
-    });
-    svg.on("mouseleave", () => {
-      tooltipdiv.style("opacity", 0);
-    });
+  }
+
+  addTextProperties(
+    stexts: d3.Selection<any, any, any, any>,
+    elementInFocus: string,
+    nodeExtremas: NodeExtremas
+  ) {
+    const vis = this;
+    stexts
+      .attr("text-anchor", (d: any) => {
+        if (d.cat === nodeExtremas.min) {
+          return "start";
+        }
+        if (d.cat === nodeExtremas.max) {
+          return "end";
+        } else {
+          return "middle";
+        }
+      })
+      .style("fill", function (d: any) {
+        return d.nodeName === elementInFocus
+          ? "#551A8B"
+          : "#0000EE";
+      })
+      .style("text-decoration", function (d: any) {
+        return  "underline";
+      })
+      .style("font-weight", function (d: any) {
+        return d.nodeName === elementInFocus ? 700 : null;
+      })
+      .style("cursor", function (d: any) {
+        return  "pointer";
+      })
+      .attr("alignment-baseline", "central")
+      .on("click", function (e: Event, d: TransformedLabel) {
+        vis.changeElementInFocus(d.nodeName);
+      })
+      .call(insertBB);
+  }
+
+  computeAxes(transformedLabels: TransformedLabel[]) {
+    const maxX = Math.max(getMax(transformedLabels, "x"), 0.01); //making sure that x is positive to handle the case where there are only one variable.
+    const maxY = getMax(transformedLabels, "y");
+
+    const x = d3
+      .scaleLinear()
+      .domain([-maxX * 0.05, maxX * 1.05])
+      .range([0.1, Math.max(this.width - 10, 800) * 0.9]);
+
+    const yfromDomain = -0.5;
+    const ytoDomain = Math.max(10, maxY);
+    const y = d3.scaleLinear().domain([yfromDomain, ytoDomain]).range([0, 800]);
+    return { x, y, yfromDomain, ytoDomain, maxX };
   }
 
   clear() {
     console.log("inside clear");
     d3.select(".arrowexplanation").remove();
-    d3.select('body')
-      .append("div")
-      .attr("class", "arrowexplanation")
-      .style("opacity", 0);
     d3.select("svg").remove();
   }
+
+  computeDataTransformations(elementInFocus: string) {
+    const pdat: PlottingInfo = this.rdat.makePlottingInstructions(
+      elementInFocus
+    );
+    const transformedLabels = pdat.transformedLabels;
+    const arrows = pdat.arrows;
+    let nodeExtremas = pdat.nodeExtremas;
+    if (nodeExtremas.min === nodeExtremas.max) {
+      nodeExtremas.min = NODE_ORDER[0];
+      nodeExtremas.max = NODE_ORDER[NODE_ORDER.length - 1];
+    }
+    const xDivisions = pdat.xDivisions;
+    return { transformedLabels, arrows, nodeExtremas, xDivisions };
+  }
+
+  update(newElementInFocus: string) {
+    const {
+      transformedLabels,
+      arrows,
+      nodeExtremas,
+      xDivisions,
+    } = this.computeDataTransformations(newElementInFocus);
+    const { x, y, yfromDomain, ytoDomain, maxX } = this.computeAxes(
+      transformedLabels
+    );
+
+    const backgroundBoxes = this.svg
+      .selectAll(".darkrect")
+      .data(xDivisions, function (d: any) {
+        return d.cat;
+      });
+    backgroundBoxes
+      .call((selection) => {
+        insertColor(selection, xDivisions);
+      })
+      .lower()
+      .transition("appearNewBackgrounds")
+      .duration(500)
+      .attr("x", (d: any) => x(d.x0))
+      .attr("width", (d: any) => x(d.x0 + d.width) - x(d.x0))
+      .style("fill", (d: any) => d.color)
+      .style("opacity", 0.5);
+
+
+    const categoryText = this.svg.selectAll(".cattext")
+      .data(xDivisions, function (d: any) {
+        return d.cat;
+      })
+      .transition("adjuse_top_labels")
+      .duration(500)
+      .attr("x", (d:any) => x(d.x0))
+      .text( function(d:any){
+        if(d.width>0){
+          return d.cat;
+        }
+        return undefined;
+      })
+      .style("opacity", function(d:any){
+        if(d.width>0){
+          return 1;
+        }
+        return 0;
+      })
+
+
+    const stext = this.svg
+      .selectAll(".linktext")
+      .data(transformedLabels, function (d: any) {
+        return d.nodeName;
+      });
+
+    stext
+      .join(
+        (enter: any) => {
+          return enter
+            .append("text")
+            .attr("class", "linktext")
+            .attr("y", (d: any) => y(d.y) as number)
+            .attr("x", (d: any) => x(d.x) as number)
+            .text((d: any) => d.nodeName)
+            .style("opacity", 0);
+        },
+        (exit) => {
+          return exit;
+        },
+        (update) => {
+          return update;
+        }
+      )
+      .call((select) => {
+        this.addTextProperties(select, newElementInFocus, nodeExtremas);
+      })
+      .transition("move_labels")
+      .duration(500)
+      .attr("y", (d: any) => y(d.y) as number)
+      .attr("x", (d: any) => x(d.x) as number)
+      .text((d: any) => d.nodeName)
+      .style("opacity", 1);
+
+    stext
+      .exit()
+      .transition("fadeout_labels")
+      .duration(250)
+      .style("opacity", 0)
+      .remove();
+
+    let nodeDic: PlottingNodeDic = {};
+
+    transformedLabels.forEach((ut: any) => {
+      nodeDic[ut.key] = ut;
+    });
+
+    let adjustedArrows = arrows.map((a: Arrow) => {
+      return {
+        ...a,
+        ...computeArrowEndPoints(
+          nodeDic[a.from],
+          nodeDic[a.to],
+          x,
+          y,
+          nodeExtremas
+        ),
+      };
+    });
+
+    const underlines = this.svg
+      .selectAll(".underlines")
+      .data(adjustedArrows, function (d: any) {
+        return d.from + " - " + d.to;
+      });
+    underlines
+      .join((enter) => {
+        return enter
+          .append("line")
+          .attr("class", "underlines")
+          .attr("x1", (d: any) => d.x1)
+          .attr("y1", (d: any) => d.y1)
+          .attr("x2", (d: any) => d.x2)
+          .attr("y2", (d: any) => d.y2)
+          .attr("stroke-width", "1")
+          .attr("stroke", "black")
+          .attr("marker-end", (d: any) => {
+            return d.type === "arrow" ? "url(#triangle)" : null;
+          })
+          .style("opacity", 0);
+      })
+      .transition("lines_move")
+      .duration(500)
+      .attr("x1", (d: any) => d.x1)
+      .attr("y1", (d: any) => d.y1)
+      .attr("x2", (d: any) => d.x2)
+      .attr("y2", (d: any) => d.y2)
+      .transition()
+      .duration(250)
+      .style("opacity", 1);
+
+    const overlines = this.svg
+      .selectAll(".overlines")
+      .data(adjustedArrows, function (d: any) {
+        return d.from + " - " + d.to;
+      });
+
+    overlines
+      .join((enter) => {
+        return enter
+          .append("line")
+          .attr("class", "overlines")
+          .attr("x1", (d: any) => d.x1)
+          .attr("y1", (d: any) => d.y1)
+          .attr("x2", (d: any) => d.x2)
+          .attr("y2", (d: any) => d.y2)
+          .attr("stroke-width", "15")
+          .attr("stroke", "black")
+          .attr("opacity", 0)
+          .attr("cursor", "pointer")
+          .call((select) => {
+            this.addFunctionalityToOverLines(select);
+          });
+      })
+      .transition("overlines_move")
+      .duration(500)
+      .attr("x1", (d: any) => d.x1)
+      .attr("y1", (d: any) => d.y1)
+      .attr("x2", (d: any) => d.x2)
+      .attr("y2", (d: any) => d.y2);
+
+    overlines.exit().remove();
+  }
+}
+
+function insertColor(
+  selection: d3.Selection<any, any, any, any>,
+  xDivisions: XDivision[]
+) {
+  const nonZeroCats = xDivisions.filter((v: XDivision) => v.width > 0).map(v=>  v.cat);
+  selection.each(function (d: any) {
+    let i = nonZeroCats.indexOf(d.cat);
+    if(i===-1){
+      d.color=ALTERNATING_COLORS[1]
+    }
+    else{
+      d.color = ALTERNATING_COLORS[i%2];
+    }
+    
+  });
 }
 
 function insertBB(selection: d3.Selection<any, any, any, any>) {

--- a/death-causes-app/src/components/RelationLinkVizWrapper.tsx
+++ b/death-causes-app/src/components/RelationLinkVizWrapper.tsx
@@ -51,8 +51,7 @@ const RelationLinkWrapper = (props: RelationLinkWrapperProps) => { //class Chart
 	useEffect(() => {
 		console.log('dataset changed');
 		if (chart) {
-			chart.clear();
-			createNewChart()
+			chart.update(elementInFocus);
 		}
 	}, [elementInFocus]);
 

--- a/death-causes-app/src/models/RelationLinks.ts
+++ b/death-causes-app/src/models/RelationLinks.ts
@@ -80,7 +80,7 @@ interface DirectionInfo {
   usedKeys: string[];
 }
 
-interface XDivision {
+export interface XDivision {
   x0: number;
   width: number;
   cat: NodeType;
@@ -218,15 +218,12 @@ export default class RelationLinks {
     } else if (fromType === NodeType.CONDITION) {
       res += "The status of " + fromNode + " is used ";
     } else if (fromType === NodeType.CAUSE_CATEGORY) {
-      res +=
-        "The risk factors common to all types of " + fromNode + " are used ";
+      return toNode +" is a type of " + fromNode 
     }
     if (toType === NodeType.COMPUTED_FACTOR) {
       res += "to compute " + toNode;
     } else if (toType === NodeType.CONDITION) {
       res += "to estimate the status of " + toNode;
-    } else if (toType === NodeType.CAUSE_CATEGORY && fromType === NodeType.CAUSE_CATEGORY) {
-      res += "as risk factors for all types of " + toNode;
     } else if (toType === NodeType.CAUSE_CATEGORY) {
       res += "as a risk factor for all types of " + toNode;
     } else if (toType === NodeType.CAUSE) {
@@ -418,13 +415,11 @@ export default class RelationLinks {
     });
     let xDivisions: XDivision[] = [];
     for (let index = 0; index < cumWeights.length - 1; index++) {
-      if (weights[index] > 0) {
-        xDivisions.push({
-          x0: cumWeights[index],
-          width: weights[index],
-          cat: NODE_ORDER[index],
-        });
-      }
+      xDivisions.push({
+        x0: cumWeights[index],
+        width: weights[index],
+        cat: NODE_ORDER[index],
+      });
     }
 
     return { transformedLabels: resDat, xDivisions: xDivisions };
@@ -642,10 +637,11 @@ export default class RelationLinks {
     childType: string,
     xDirection: (x: number) => number
   ) {
-    if (xDirection(0.2) === 0.2) {
-      return parentType === NodeType.CAUSE_CATEGORY ? "no-arrow" : "arrow";
-    }
-    return childType === NodeType.CAUSE_CATEGORY ? "no-arrow" : "arrow";
+    return "arrow";
+    // if (xDirection(0.2) === 0.2) {
+    //   return parentType === NodeType.CAUSE_CATEGORY ? "no-arrow" : "arrow";
+    // }
+    // return childType === NodeType.CAUSE_CATEGORY ? "no-arrow" : "arrow";
   }
 
   followMaximumSumOfSummary(


### PR DESCRIPTION
Jeg har tilføjet animationer på overgangene mellem forskellige relationlink grafer. Firkanterne i baggrunden var lidt irriterende at få til at lave pæne transitioner, og nu ændrer jeg farverne i transitionen, og det ser måske ikke helt super ud. 

Derudover har jeg gjort death cause category  til en node-type på samme niveau som alle de andre i relationlinkgrafen. Dvs. der udgår pile fra den og skriften er lavet med den klassiske link type. 