### PR TITLE
fixed unlucky design and css features

### DIFF
--- a/death-causes-app/src/AboutPage.css
+++ b/death-causes-app/src/AboutPage.css
@@ -1,9 +1,4 @@
-.container {
-    width: 60%;
-    min-width: 300px;
-}
-
-.div {
+#aboutpage {
     display:block;
     margin-left: auto;
     margin-right: auto;

--- a/death-causes-app/src/Main.css
+++ b/death-causes-app/src/Main.css
@@ -17,9 +17,6 @@
   color: #61dafb;
 }
 
-.container{
-  width: 95%
-}
 
 .submitbutton {
   width: 100px;

--- a/death-causes-app/src/Main.tsx
+++ b/death-causes-app/src/Main.tsx
@@ -21,6 +21,7 @@ class MainWithoutObserver extends React.Component<MainProps> {
       styleObject["overflow"] = "auto"
     } else {
       styleObject["overflow"] = "hidden"
+      styleObject["minHeight"]="350px"
     }
     return (
       <div className="Main">

--- a/death-causes-app/src/components/AskedQuestionFrame.tsx
+++ b/death-causes-app/src/components/AskedQuestionFrame.tsx
@@ -61,7 +61,8 @@ class AskedQuestionFramedWithoutStore extends React.Component<AskedQuestionProps
   getMovingOnButton(){
     const disabled=(this.props.validity !== undefined  && 
         this.props.validity.status === "Error") || 
-      this.props.store.computationStateStore.computationState===ComputationState.RUNNING
+      this.props.store.computationStateStore.computationState===ComputationState.RUNNING ||
+      !this.props.store.loadedDataStore.loadedVizWindowData
     let buttonStyle: FormControlStyle={};
     let onClick: (ev: React.FormEvent) => void;
     let buttonText: string;
@@ -95,9 +96,10 @@ class AskedQuestionFramedWithoutStore extends React.Component<AskedQuestionProps
 
 
   render() {
+    const minHeight = this.props.store.uIStore.windowWidth<501 ? "360px" : "300px"
     return (
       <div>
-      <Card style={{ marginBottom: "20px", minHeight: "300px", maxHeight:"300px",maxWidth:"500px",marginRight:"auto", marginLeft:"auto" }}>
+      <Card style={{ marginBottom: "20px", minHeight: minHeight,maxWidth:"500px",marginRight:"auto", marginLeft:"auto" }}>
         <Card.Header>
         <div className="d-flex justify-content-between">
           <div>
@@ -113,7 +115,7 @@ class AskedQuestionFramedWithoutStore extends React.Component<AskedQuestionProps
         </Card.Header>
         <Card.Body>{this.props.children}</Card.Body>
         <Card.Footer>
-          <ButtonToolbar className="justify-content-between">
+          <ButtonToolbar className="d-flex justify-content-between flex-wrap">
             <ButtonGroup>
               <Button
                 disabled={!this.previousPossible()}

--- a/death-causes-app/src/components/BarChart.css
+++ b/death-causes-app/src/components/BarChart.css
@@ -92,7 +92,7 @@
       }
       
       .buttontip.n:before {
-        top: 31px;
+        top: calc(100% - 2px);
         left: 0;
       }
   

--- a/death-causes-app/src/components/BarChart.tsx
+++ b/death-causes-app/src/components/BarChart.tsx
@@ -25,6 +25,7 @@ const SELECTED_DISEASE_COLOR = "#a3e3f0";
 const WIDTH_PROPORTION= 0.95
 const STIP_MAX_WIDTH=150;
 const CLICKTIP_MAX_WIDTH=250;
+const CAUSE_HEADER_LENGTH=35;
 
 
 function getDivWidth(div: HTMLElement | null): number {
@@ -69,7 +70,7 @@ const sameConstants = {
     "translate(" + 10 + "," + (-BARHEIGHT / 16 - buttonSize) + ")",
   collapseButtonsWidth: buttonSize,
   collapseButtonsHeight: buttonSize,
-  airToTheRight: 0.15,
+  airToTheRight: 80,
 };
 
 function longDesignConstants(
@@ -94,7 +95,7 @@ function longDesignConstants(
     width: width,
     textTranslation: "translate(" + 10 + "," + -BARHEIGHT / 8 + ")",
     textAnchor: "start",
-    airToTheRight: simplifiedVersion ? 0.01 : 0.15,
+    airToTheRight: simplifiedVersion ? 1 : 80,
   };
 }
 
@@ -274,7 +275,7 @@ export default class BarChart {
       .attr("y", 0)
       .attr("x", 0)
       .text(function (d: any) {
-        return vis.descriptions.getDescription(d.name, 100);
+        return vis.descriptions.getDescription(d.name, CAUSE_HEADER_LENGTH);
       })
       .style("text-anchor", designConstants.textAnchor)
       .attr("transform", designConstants.textTranslation)
@@ -688,18 +689,16 @@ export default class BarChart {
         if(overflowRight<0){
           middlePoint+=overflowRight
         }
-        if (vis.clickedSquareSection !== d) {
-          vis.stip
-            .style("display", "block")
-            .html(d.comparison ? d.comparison : d.cause)
-            .style("left", (middlePoint).toString() + "px")
-            .style("top", (bbox.y+bbox.height+12).toString() + "px");
-          vis.stiparrow
-            .style("display", "block")
-            .html("\u25B2")
-            .style("left", (bbox.x+bbox.width/2-6).toString() + "px")
-            .style("top", (bbox.y+bbox.height-4).toString() + "px");
-        }
+        vis.stip
+          .style("display", "block")
+          .html(d.comparison ? d.comparison : d.cause)
+          .style("left", (middlePoint).toString() + "px")
+          .style("top", (bbox.y+bbox.height+12).toString() + "px");
+        vis.stiparrow
+          .style("display", "block")
+          .html("\u25B2")
+          .style("left", (bbox.x+bbox.width/2-6).toString() + "px")
+          .style("top", (bbox.y+bbox.height-4).toString() + "px");
         d3.select(this)
           .raise()
           .style("stroke-width", 3)
@@ -731,7 +730,7 @@ export default class BarChart {
           .style("display", "block")
           .html(`${d.longComparison ? d.longComparison.textWithButtons : d.cause}`)
           .style("left", (middlePoint).toString() + "px")
-          .style("top", (bbox.y+bbox.height+12).toString() + "px");
+          .style("top", (bbox.y+bbox.height+12).toString() + "px")
         if(d.longComparison){
           vis.addButtonActions(d.longComparison.buttonCodes)
         }
@@ -739,7 +738,7 @@ export default class BarChart {
           .style("display", "block")
           .html("\u25B2")
           .style("left", (bbox.x+bbox.width/2-6).toString() + "px")
-          .style("top", (bbox.y+bbox.height-4).toString() + "px");
+          .style("top", (bbox.y+bbox.height-4).toString() + "px")
         vis.clickedSquareSection = d;
         vis.stip.style("display","none")
         vis.stiparrow.style("display","none")
@@ -751,7 +750,6 @@ export default class BarChart {
     buttonCodes.forEach((nodeName, index) => {
       d3.select("#but"+(index+1).toString())
         .on("click", (e)=> { 
-          e.stopPropagation();
           this.redirectPage(nodeName)  
         });
     })
@@ -760,10 +758,13 @@ export default class BarChart {
   createXAxisCall(newMax: number, designConstants: DesignConstants) {
     const x = d3
       .scaleLinear()
-      .domain([0, newMax * (1 + designConstants.airToTheRight)])
-      .range([designConstants.startXScale, designConstants.width]);
+      .domain([0, newMax])
+      .range([
+        designConstants.startXScale, 
+        designConstants.width-designConstants.airToTheRight
+        ]);
     this.xscale = x;
-    return d3.axisTop(x);
+    return d3.axisTop(x).ticks(4);
   }
 
   instantUpdateOfRects(
@@ -1038,7 +1039,7 @@ export default class BarChart {
       this.xAxisGroup
         .transition("x_axis_change")
         .duration(durationPerTransition)
-        .call(xAxisCall);
+        .call(xAxisCall)
     }
     return newMaxX;
   }

--- a/death-causes-app/src/components/BarChartWrapper.tsx
+++ b/death-causes-app/src/components/BarChartWrapper.tsx
@@ -93,9 +93,10 @@ const BarChartWrapper = observer((props: BarChartWrapperProps) => { //class Char
 		}
 	}, []);
 
-
+	const colwidth= store.uIStore.windowWidth<501 ? "100%" : "90%"
+	const padding= store.uIStore.windowWidth<501 ? "0px" : ""
 	return (
-		<div className="container" style={{width:"90%"}}>
+		<div className="container" style={{width:colwidth, padding: padding}}>
 			<div ref={chartArea} id="barchartcontainer" style={{position:"relative", padding:"0px",margin: "auto", top:"0px",left:"0px"}} />
 		</div>
 	)

--- a/death-causes-app/src/components/BarPlotWrapper.css
+++ b/death-causes-app/src/components/BarPlotWrapper.css
@@ -1,4 +1,4 @@
-.d3-tip {
+.barplottip {
   line-height: 1;
   padding: 6px;
   background: rgba(255, 255, 255, 0.75);
@@ -9,13 +9,15 @@
   border-style: solid;
   font-size: 14px;
   font-weight: 500;
+  position: absolute;
+  transform: translate(-50%,0)
   }
   
   /* Creates a small triangle extender for the tooltip 
   */
-  .d3-tip:before {
+  .barplottip:before {
     box-sizing: border-box;
-    display: inline;
+    display: block;
     font-size: 12px;
     width: 100%;
     line-height: 1;
@@ -25,7 +27,7 @@
     text-align: center
   }
 
-  .d3-tip.n:before {
+  .barplottip:before {
     margin: -1px 0 0 0;
     top: 100%;
     left: 0;

--- a/death-causes-app/src/components/BarPlotWrapper.tsx
+++ b/death-causes-app/src/components/BarPlotWrapper.tsx
@@ -67,6 +67,7 @@ const BarPlotWrapper = observer((props: BarPlotWrapperProps) => {
       .padding(0.2)
       .domain(props.data.map((element) => element.age.toString()));
 
+    const filtering= width>700 ? 5 : (width>300 ? 10 : 20);
     var xAxis = svg
       .append("g")
       .attr("class", "xAxis")
@@ -75,7 +76,7 @@ const BarPlotWrapper = observer((props: BarPlotWrapperProps) => {
       .call(
         d3.axisBottom(x).tickValues(
           x.domain().filter(function (d: any, i: any) {
-            return !(+d % 5);
+            return !(+d % filtering);
           })
         )
       );
@@ -196,31 +197,30 @@ const BarPlotWrapper = observer((props: BarPlotWrapperProps) => {
   };
 
   const setMouseOverTips = () => {
-    d3.select(".d3-tip").remove();
+    d3.select(".barplottip").remove();
 
-    let tip = d3Tip()
-      .attr("class", "d3-tip")
-      .offset([-10, 0])
-      .html(function (d: SurvivalCurveData) {
-        return (
-          "Probability: <strong>" + formatter(d.prob) + "</strong><br/>" +
-          "of surviving past: <strong>" + d.age + "</strong>"
-        );
-      });
-
-    d3.select("g").call(tip);
+    let tip = d3
+      .select(chartArea.current)
+      .append("div")
+      .attr("class", "barplottip")
+      .style("display", "none")
 
     d3.selectAll("rect")
       .data(props.data, function (survivalcurvedat: any) { return survivalcurvedat.age.toPrecision() })
       .on("mouseenter", function (e: Event, d: SurvivalCurveData) {
-        d3.selectAll(".d3-tip")
-          .style("background-color", "9cc986")
-          .style("opacity", 1);
-        tip.show(d, this);
+        const bbox=(this as any).getBBox();
+        tip
+          .html(
+              "Probability: <strong>" + formatter(d.prob) + "</strong><br/>" +
+              "of surviving past: <strong>" + d.age + "</strong>"
+            )
+          .style("display","block")
+          .style("left", (bbox.x+margin.left+width/0.9*0.05+bbox.width/2-4).toString() + "px")
+          .style("top", (bbox.y-1).toString() + "px")
         d3.select(this).raise().style("fill", colors.barHighlight);
       })
       .on("mouseleave", function (e: Event, d: SurvivalCurveData) {
-        tip.hide(d, this);
+        tip.style("display", "none")
         d3.select(this).style("fill", colors.barFill);
       });
   };
@@ -229,12 +229,13 @@ const BarPlotWrapper = observer((props: BarPlotWrapperProps) => {
 
     let svg = d3.select(chartArea.current).select("g");
 
+    const headersize= ( width>420 ? 20 : (width>300 ? 16 : 12) ).toString()+"px";
     svg
       .append("text")
       .attr("x", width / 2)
       .attr("y", -margin.top / 2)
       .text("Probability of being alive each year")
-      .style("font-size", "20px")
+      .style("font-size", headersize)
       .attr("font-weight", 700)
       .attr("text-anchor", "middle");
 
@@ -255,6 +256,6 @@ const BarPlotWrapper = observer((props: BarPlotWrapperProps) => {
       .attr("font-weight", 700);
   };
 
-  return <div ref={chartArea} ></div>;
+  return <div ref={chartArea} style={{position:"relative"}}></div>;
 });
 export default BarPlotWrapper;

--- a/death-causes-app/src/components/Helpers.ts
+++ b/death-causes-app/src/components/Helpers.ts
@@ -6,7 +6,7 @@ export const LINK_COLOR = "#0000EE";
 export const SAVE_FILE_NAME ="personalData.json"
 export const QUERY_STRING_START = "?inputData="
 
-const toolTipNamesShowHide=['.stip','.clicktip','.d3-tip','buttontip']
+const toolTipNamesShowHide=['.stip','.clicktip','.barplottip','buttontip']
 const toolTipsOpacity=['.arrowexplanation']
 
 

--- a/death-causes-app/src/components/Question.tsx
+++ b/death-causes-app/src/components/Question.tsx
@@ -29,7 +29,7 @@ export interface QuestionProps<T>{
   name: string;
   phrasing: string;
   factorAnswer: T;
-  helpText: string;
+  helpText: string | null;
   placeholder: string;
   inputvalidity: InputValidity;
   featured: boolean;
@@ -47,7 +47,7 @@ interface QuestionContextProps extends RouteComponentProps{
   name: string;
   ignore: boolean;
   handleIgnoreFactor: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  helpText: string;
+  helpText: string | null;
   phrasing: string;
   secondLine: ReactElement | string;
   featured: boolean;
@@ -66,8 +66,8 @@ class QuestionContextWithoutStoreWithoutRouter extends React.PureComponent<Quest
     if (this.props.featured) {
       return (
         <div>
-          <MarkDown>{this.props.helpText}</MarkDown>
-          <hr></hr>
+          {this.props.helpText ? <MarkDown>{this.props.helpText}</MarkDown> : null}
+          {this.props.helpText ? <hr></hr> : null}
           {this.readMoreLink()}
           {this.props.name !== "Age" ? <hr></hr> : null}
           {this.props.name !== "Age" ? this.descendantMessage() : null}
@@ -78,8 +78,8 @@ class QuestionContextWithoutStoreWithoutRouter extends React.PureComponent<Quest
         <div>
           {this.questionPhrasing()}
           <hr></hr>
-          <MarkDown>{this.props.helpText}</MarkDown>
-          <hr></hr>
+          {this.props.helpText ? <MarkDown>{this.props.helpText}</MarkDown> : null}
+          {this.props.helpText ? <hr></hr> : null}
           {this.readMoreLink()}
           {this.props.name !== "Age" ? <hr></hr> : null}
           {this.props.name !== "Age" ? this.descendantMessage() : null}
@@ -268,14 +268,14 @@ class QuestionContextWithoutStoreWithoutRouter extends React.PureComponent<Quest
 
   inLineFactorNameHeader() {
     //const { fontSize, writtenName } = this.fontSizeForFactorNameHeader();
-    const fontSize=17;
-    const writtenName=this.props.store.loadedDataStore.descriptions.getDescription(this.props.name, 14)
+    const fontSize=this.props.store.uIStore.windowWidth<501 ? 12 : 14;
+    const writtenName=this.props.store.loadedDataStore.descriptions.getDescription(this.props.name, 15)
     return (
       <div>
         <p
           style={{
             color: this.FactorNameColor(),
-            fontWeight: "bold",
+            fontWeight:"bold",
             marginBottom: "0px",
             textAlign: "left",
             fontSize: fontSize.toPrecision() + "px",
@@ -350,7 +350,10 @@ class QuestionContextWithoutStoreWithoutRouter extends React.PureComponent<Quest
 
   getErrorMessageStyle() {
     let errorMessageStyle: FormControlStyle = {};
-    errorMessageStyle["color"] =  "";
+    errorMessageStyle["color"] = 
+      this.props.store.factorInputStore.validities[this.props.name].status === "Error" ? 
+      ERROR_COLOR : 
+      ""
     return errorMessageStyle;
   }
 

--- a/death-causes-app/src/components/QuestionListFrame.tsx
+++ b/death-causes-app/src/components/QuestionListFrame.tsx
@@ -83,7 +83,8 @@ class QuestionListFrameWithoutStore extends React.Component<QuestionListFramePro
             onClick={this.props.onSubmit}
             style={buttonStyle}
             disabled={
-              !this.props.store.factorInputStore.submittable ||
+              !this.props.store.factorInputStore.submittable || 
+              !this.props.store.loadedDataStore.loadedVizWindowData ||
               this.props.store.computationStateStore.computationState === ComputationState.RUNNING
             }
           >
@@ -124,7 +125,7 @@ class QuestionListFrameWithoutStore extends React.Component<QuestionListFramePro
         }}
       >
         <Card.Header>
-          <div className="d-flex justify-content-between">
+          <div className="d-flex justify-content-between flex-wrap">
             <div>
               <Button onClick={()=> this.props.store.questionProgressStore.switchView(QuestionView.NOTHING)}>
                 Back to the questions
@@ -136,7 +137,7 @@ class QuestionListFrameWithoutStore extends React.Component<QuestionListFramePro
         </Card.Header>
         <Card.Body>{this.props.children}</Card.Body>
         <Card.Footer>
-          <ButtonToolbar className="justify-content-between">
+          <ButtonToolbar className="d-flex justify-content-between flex-wrap">
             <ButtonGroup>
               <Button onClick={() => this.toggleSaveMenu()}>Save personal data</Button>
             </ButtonGroup>

--- a/death-causes-app/src/components/QuestionMenu.tsx
+++ b/death-causes-app/src/components/QuestionMenu.tsx
@@ -62,7 +62,7 @@ class QuestionMenuWithoutStoreWithoutRouter extends React.Component<
       this.props.store.questionProgressStore.hasBeenAnswered,
       this.props.store.questionProgressStore.currentFactor
     );
-    if (this.props.store.factorInputStore.submittable) {
+    if (this.props.store.factorInputStore.submittable && this.props.store.loadedDataStore.loadedVizWindowData) {
       this.props.store.questionProgressStore.nextQuestion(this.props.store.factorInputStore.factorMaskings);
       this.props.store.computationStore.compute(this.props.store.factorInputStore.computeSubmittedAnswers());
       if(this.props.store.uIStore.visualization===Visualization.NO_GRAPH){
@@ -71,7 +71,7 @@ class QuestionMenuWithoutStoreWithoutRouter extends React.Component<
     }
   }
 
-  getHelpText(factorName: string): string {
+  getHelpText(factorName: string): string | null{
     return this.props.store.loadedDataStore.factors.getHelpJson(factorName);
   }
 
@@ -142,14 +142,6 @@ class QuestionMenuWithoutStoreWithoutRouter extends React.Component<
       }
     }
   }
-
-
-
-
-
-
-
-
 
   getQuestionToAnswer() {
     if (this.props.store.questionProgressStore.answeringProgress === AnswerProgress.FINISHED) {

--- a/death-causes-app/src/components/QuestionOptions.tsx
+++ b/death-causes-app/src/components/QuestionOptions.tsx
@@ -57,7 +57,7 @@ class QuestionOptionsWithoutStore extends React.Component<
       factorMaskings,
     } = this.props.store.loadedDataStore.factors.simulateFactorAnswersAndMaskings();
     this.props.store.factorInputStore.setFactorAnswers(factorAnswers, factorMaskings)
-    this.props.store.questionProgressStore.finishQuestionnaire();
+    this.props.store.questionProgressStore.finishQuestionnaireStartOverview();
   }
 
   render() {
@@ -67,7 +67,7 @@ class QuestionOptionsWithoutStore extends React.Component<
           <Dropdown.Item onClick={this.startOverQuestionnaire}>
             Start over
           </Dropdown.Item>
-          <Dropdown.Item onClick={this.props.store.questionProgressStore.finishQuestionnaire} disabled={this.props.disableGoToEnd}>
+          <Dropdown.Item onClick={this.props.store.questionProgressStore.finishQuestionnaireStartOverview} disabled={this.props.disableGoToEnd}>
             Go to end
           </Dropdown.Item>
           <Dropdown.Item onClick={this.insertRandom}>

--- a/death-causes-app/src/components/RelationLinkViz.tsx
+++ b/death-causes-app/src/components/RelationLinkViz.tsx
@@ -15,6 +15,7 @@ import "./RelationLinkViz.css";
 
 const DESCRIPTION_LENGTH=22
 const SLIGHTLY_DARKER_GRAY="#707070"
+const BOTTOM_BUFFER_HEIGHT=16
 interface PlottingNodeDicValue {
   bbox: SVGRect;
   x: number;
@@ -90,8 +91,8 @@ export default class RelationLinkViz {
       .attr("class", "darkrect")
       .attr("x", (d: any) => x(d.x0))
       .attr("width", (d: any) => x(d.x0 + d.width) - x(d.x0))
-      .attr("y", y(yfromDomain))
-      .attr("height", y(ytoDomain) - y(yfromDomain))
+      .attr("y", 0)
+      .attr("height", y(ytoDomain) - y(yfromDomain)+BOTTOM_BUFFER_HEIGHT*2)
       .style("fill", (d: any) => d.color)
       .style("opacity", 0.8);
 
@@ -103,7 +104,7 @@ export default class RelationLinkViz {
       .append("text")
       .attr("class","cattext")
       .attr("x", (d:any) => x(d.x0))
-      .attr("y", y(yfromDomain))
+      .attr("y", 0)
       .text( function(d:any){
         if(d.width>0){
           return d.cat;
@@ -113,7 +114,7 @@ export default class RelationLinkViz {
       .style("fill", SLIGHTLY_DARKER_GRAY)
       .style("font-size","14px")
       .attr("text-anchor", "start")
-      .attr("alignment-baseline", "hanging")
+      .attr("dominant-baseline", "hanging")
       .style("opacity", function(d:any){
         if(d.width>0){
           return 1;
@@ -302,7 +303,7 @@ export default class RelationLinkViz {
       .style("cursor", function (d: any) {
         return  "pointer";
       })
-      .attr("alignment-baseline", "central")
+      .attr("dominant-baseline", "central")
       .on("click", function (e: Event, d: TransformedLabel) {
         vis.changeElementInFocus(d.nodeName);
       })
@@ -316,11 +317,11 @@ export default class RelationLinkViz {
     const x = d3
       .scaleLinear()
       .domain([-maxX * 0.05, maxX * 1.05])
-      .range([0.1, Math.max(this.width - 10, 800) * 0.9]);
+      .range([0.1, Math.max(this.width - 10, 800)]);
 
     const yfromDomain = -0.5;
     const ytoDomain = Math.max(10, maxY);
-    const y = d3.scaleLinear().domain([yfromDomain, ytoDomain]).range([0, 800]);
+    const y = d3.scaleLinear().domain([yfromDomain, ytoDomain]).range([BOTTOM_BUFFER_HEIGHT, 1000- BOTTOM_BUFFER_HEIGHT]);
     return { x, y, yfromDomain, ytoDomain, maxX };
   }
 
@@ -381,6 +382,7 @@ export default class RelationLinkViz {
       .transition("adjuse_top_labels")
       .duration(500)
       .attr("x", (d:any) => x(d.x0))
+      .attr("y", (d:any) => 0)
       .text( function(d:any){
         if(d.width>0){
           return d.cat;

--- a/death-causes-app/src/components/RelationLinkVizWrapper.css
+++ b/death-causes-app/src/components/RelationLinkVizWrapper.css
@@ -2,9 +2,9 @@
     display: 'block';
     min-width: 800;
     padding: 5px;
-    border: 1px solid rgb(129, 129, 129);
-    border-radius: 4px;
     position: relative;
+    overflow-x: hidden;
+    overflow-y:hidden;
 }
 
 .select {

--- a/death-causes-app/src/components/RelationLinkVizWrapper.tsx
+++ b/death-causes-app/src/components/RelationLinkVizWrapper.tsx
@@ -76,7 +76,9 @@ const RelationLinkWrapper = observer((props: RelationLinkWrapperProps) => { //cl
 				variant="link"
 				onClick={()=> onRedirectToLibrary(store.relationLinkVizStore.elementInFocus)}> 
 				{store.loadedDataStore.descriptions.getDescription(store.relationLinkVizStore.elementInFocus, DESCRIPTION_LENGTH)} </Button></p>
-		<div className="containerRelationLink" ref={chartArea} id="relationlinkcontainer"/>
+				<div style={{overflowX:"auto", width: "100%"}}>
+					<div className="containerRelationLink" ref={chartArea} id="relationlinkcontainer"/>
+				</div>
 		</div>
 	)
 

--- a/death-causes-app/src/components/SummaryView.tsx
+++ b/death-causes-app/src/components/SummaryView.tsx
@@ -55,9 +55,11 @@ export class SummaryViewWithoutStore extends React.Component<SummaryViewProps> {
         const lifeExpentancy = summaryViewData.lifeExpentancyData.lifeExpentancy.toLocaleString("en-US", { maximumFractionDigits: 1, minimumFractionDigits: 1 });
         const textColor = summaryViewData.lifeExpentancyData.lifeExpentancy > 70 ? "green" : "red"
 
+        const colwidth= this.props.store.uIStore.windowWidth>501 ? "70%" : "100%" 
+
         return (
             <Fragment>
-                <Col className="mx-auto my-1" style={{ width: "70%" }}>
+                <Col className="mx-auto my-1" style={{ width: colwidth }}>
                     <Card className="my-1 mx-auto bg-light " style={{}}>
                         <CardBody>
                             <h3>Your life expectancy is: <span style={{ color: textColor }}>{lifeExpentancy}</span> years</h3>
@@ -73,11 +75,11 @@ export class SummaryViewWithoutStore extends React.Component<SummaryViewProps> {
                         </CardBody>
                     </Card>
                 </Col>
-                <Col className="mx-auto my-1" style={{ width: "70%" }}>
-                    <Card className="bg-light " style={{}}>
+                <Col className="mx-auto my-1" style={{ width: colwidth }}>
+                    <Card className="bg-light ">
                         <CardHeader><h4>Contribution from risk Factors</h4></CardHeader>
                         <CardBody>
-                            <p className="mx-5">The bar below represents your total probability of dying. Each section shows how much each factor contribute to your total probability of dying.</p>
+                            <p>The bar below represents your total probability of dying. Each section shows how much each factor contribute to your total probability of dying.</p>
                             <BarChartWrapper database={this.props.store.computationStore.riskFactorContributions} simpleVersion={true} />
                         </CardBody>
                     </Card>

--- a/death-causes-app/src/components/VizWindow.tsx
+++ b/death-causes-app/src/components/VizWindow.tsx
@@ -34,7 +34,7 @@ class VizWindowWithoutStore extends React.PureComponent<VizWindowProps, VizWindo
     this.state = {
       riskFactorContributions: this.props.store.computationStore.riskFactorContributions,
       survivalCurveData: this.props.store.computationStore.survivalCurveData,
-      summaryViewData: null
+      summaryViewData: this.props.store.computationStore.summaryView
     }
   }
 

--- a/death-causes-app/src/models/Factors.ts
+++ b/death-causes-app/src/models/Factors.ts
@@ -284,10 +284,10 @@ class Factors {
     return this.factorOrder;
   }
 
-  getHelpJson(factorname: string): string {
+  getHelpJson(factorname: string): string | null{
     return this.factorList[factorname].helpJson
       ? (this.factorList[factorname].helpJson as string)
-      : "No help available";
+      : null;
   }
 
   getFactorsAsStateObject() {

--- a/death-causes-app/src/stores/LoadedDataStore.tsx
+++ b/death-causes-app/src/stores/LoadedDataStore.tsx
@@ -60,6 +60,9 @@ export default class LoadedDataStore {
     const promiseOfRelationLinks= this.makePromiseOfRelationsLinks();
     const promiseOfDatabase = this.makePromiseOfDataBase();
     const promiseOfConditions=this.makePromiseOfConditions();
+    const artificialWaiting= new Promise<number>( (res) => {
+      setTimeout(()=>{ res(9)},5000)
+    })
     Promise.all([promiseOfFactors, promiseOfDescriptions]).then(() => {
       factorInputStore.attachLoadedData();
       questionProgressStore.attachLoadedData();


### PR DESCRIPTION
- Har lagt barplot'tets tooltip ind i barplottet (og ikke i body) sådan at den ikke følger med når man scroller. 
- Har ændret bredden på vizwindow indholdet sådan at den fylder bredden bedre ud når skærmen er lille. 
- Hopper nu helt frem til questionlistview når man trykker "go to end" eller "randomize everything".
- gjort højden af askedquestionframe responsivt
- givet højresiden af barchartplottet konstant bredde så der altid er plads til tekst og knapper
- ladet knapperne på questionlistview og askedquestionview gå ned på to linjer på meget små skærme
- tillader ingen submits inden data er loadet
- fikset manglende tekst i firefox på relation link viz (ved at bruge dominant-baseline i stedet for alignment-baseline)
- droppet "no help available" i helpbox, for nu er der jo biblioteket at kigge i.

